### PR TITLE
Address Luau typing issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Packages
 ServerPackages
 roblox.toml
 *.rbxm
+sourcemap.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "update packages",
+            "type": "shell",
+            "command": "wally install; rojo sourcemap default.project.json; wally-package-types --sourcemap sourcemap.json Packages/",
+            "presentation": {
+                "reveal": "never"
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,8 @@
+# This file lists tools managed by Aftman, a cross-platform toolchain manager.
+# For more information, see https://github.com/LPGhatguy/aftman
+
+# To add a new tool, add an entry to this table.
+[tools]
+rojo = "rojo-rbx/rojo@7.2.1"
+wally = "UpliftGames/wally@0.3.1"
+wally-package-types = "JohnnyMorganz/wally-package-types@1.0.0"

--- a/default.project.json
+++ b/default.project.json
@@ -1,6 +1,15 @@
 {
 	"name": "rodux-hooks",
 	"tree": {
-		"$path": "src"
+		"$className": "DataModel",
+		"ReplicatedStorage": {
+			"$className": "ReplicatedStorage",
+			"Packages": {
+				"$path": "Packages",
+				"rodux-hooks": {
+					"$path": "src"
+				}
+			}
+		}
 	}
 }

--- a/src/Context.lua
+++ b/src/Context.lua
@@ -1,5 +1,5 @@
 local Roact = require(script.Parent.Parent.Roact)
 
-local Context = Roact.createContext()
+local Context = Roact.createContext(nil)
 
 return Context

--- a/src/useCustomDispatch.lua
+++ b/src/useCustomDispatch.lua
@@ -3,9 +3,9 @@ local Roact = require(script.Parent.Parent.Roact)
 local function useCustomDispatch(context)
 	local store = Roact.useContext(context)
 
-    return function(action)
-        store:dispatch(action)
-    end
+	return function(action)
+		return store:dispatch(action)
+	end
 end
 
 return useCustomDispatch

--- a/src/useCustomSelector.lua
+++ b/src/useCustomSelector.lua
@@ -4,11 +4,7 @@ local function defaultEqualityFn(newState, oldState)
 	return newState == oldState
 end
 
-local function useCustomSelector(
-	selector: (state: table) -> any,
-	equalityFn: ((newState: table, oldState: table) -> boolean)?,
-	context
-)
+local function useCustomSelector<R, S>(selector: (S) -> R, equalityFn: ((S, S) -> boolean)?, context): R
 	local store = Roact.useContext(context)
 	local mappedState, setMappedState = Roact.useState(function()
 		return selector(store:getState())
@@ -18,6 +14,7 @@ local function useCustomSelector(
 	if equalityFn == nil then
 		equalityFn = defaultEqualityFn
 	end
+	assert(equalityFn, "should exist")
 
 	Roact.useEffect(function()
 		local storeChanged = store.changed:connect(function(newState, _oldState)

--- a/src/useSelector.lua
+++ b/src/useSelector.lua
@@ -1,10 +1,7 @@
 local Context = require(script.Parent.Context)
 local useCustomSelector = require(script.Parent.useCustomSelector)
 
-local function useSelector(
-	selector: (state: table) -> any,
-	equalityFn: ((newState: table, oldState: table) -> boolean)?
-)
+local function useSelector<R, S>(selector: (S) -> R, equalityFn: ((S, S) -> boolean)?): R
 	return useCustomSelector(selector, equalityFn, Context)
 end
 

--- a/wally.lock
+++ b/wally.lock
@@ -98,6 +98,6 @@ version = "1.1.1"
 dependencies = []
 
 [[package]]
-name = "solarhorizon/rodux-hooks"
+name = "metrowaii/rodux-hooks"
 version = "0.3.0"
 dependencies = [["Roact", "core-packages/roact-compat@17.0.1-rc.16.1"]]


### PR DESCRIPTION
When using this library, I encountered many type-errors. I noticed a lot of the Luau typings were invalid. I've updated the signatures of useSelector and useDispatch to no longer have these type-errors.

To enable Luau LSP support:
- Added aftman.toml
- Updated default.project.json to include Packages folder
- Updated .gitignore

Code changes:
- Updated type signatures for useSelector, useCustomSelector, useDispatch, and useCustomDispatch
- Gave Roact.createContext a default value of nil since it expects 1 or 2 arguments.
- useCustomDispatch will return a value to allow for return values to be passed to useDispatch when dispatching thunks.


## Before
![image](https://user-images.githubusercontent.com/5725602/208821255-e41708b1-8837-4fa0-9692-2aa481a238f2.png)

## After
![image](https://user-images.githubusercontent.com/5725602/208820927-8a256a62-c2cb-40c3-90ea-883a0ff8a9ec.png)
